### PR TITLE
Move layer control to avoid interaction with legend

### DIFF
--- a/bas_geoplot/interactive.py
+++ b/bas_geoplot/interactive.py
@@ -209,7 +209,7 @@ class Map:
         """
 
         self._add_plots_map()
-        folium.LayerControl(collapsed=True).add_to(self.map)
+        folium.LayerControl('topleft', collapsed=True).add_to(self.map)
         return self.map
 
     def save(self,file):


### PR DESCRIPTION
This change just moves the layer control to the top left to avoid the problem described in #37 