### PR TITLE
Add method to zoom map to plotted layers

### DIFF
--- a/bas_geoplot/cli.py
+++ b/bas_geoplot/cli.py
@@ -86,6 +86,7 @@ def plot_mesh_cli():
         waypoints = pd.DataFrame(info['waypoints'])
         mp.Points(waypoints,'Waypoints',names={"font_size":10.0})
     mp.MeshInfo(mesh,'Mesh Info',show=False)
+    mp.fit_to_layers()
     logging.info('Saving plot to {}'.format(args.output))
     mp.save(args.output)
 

--- a/bas_geoplot/cli.py
+++ b/bas_geoplot/cli.py
@@ -29,9 +29,12 @@ def plot_mesh_cli():
     logging.info("{} {}".format(inspect.stack()[0][3][:-4], version))
     info = json.load(args.mesh)
     mesh = pd.DataFrame(info['cellboxes'])
+    region = info['config']['Mesh_info']['Region']
 
     output = ' '.join(args.output.split('/')[-1].split('.')[:-1])
-    output = '{} | Start Date: {}, End Date: {}'.format(output, info['config']['Mesh_info']['Region']['startTime'], info['config']['Mesh_info']['Region']['endTime'])
+    output = '{} | Start Date: {}, End Date: {}'.format(output, region['startTime'], region['endTime'])
+
+    mesh_bounds = [[region["latMin"], region["longMin"]], [region["latMax"], region["longMax"]]]
 
 
     if args.offline_filepath != '':
@@ -86,7 +89,7 @@ def plot_mesh_cli():
         waypoints = pd.DataFrame(info['waypoints'])
         mp.Points(waypoints,'Waypoints',names={"font_size":10.0})
     mp.MeshInfo(mesh,'Mesh Info',show=False)
-    mp.fit_to_layers()
+    mp.fit_to_bounds(mesh_bounds)
     logging.info('Saving plot to {}'.format(args.output))
     mp.save(args.output)
 

--- a/bas_geoplot/interactive.py
+++ b/bas_geoplot/interactive.py
@@ -249,6 +249,12 @@ class Map:
             fp.write(html)
             fp.close()
 
+    def fit_to_layers(self):
+        """
+            Change zoom level to match plotted data
+        """
+        self.map.fit_bounds(self.map.get_bounds())
+
 
     def Paths(self,geojson,name,show=True,predefined=None,**kwargs):
         """

--- a/bas_geoplot/interactive.py
+++ b/bas_geoplot/interactive.py
@@ -15,6 +15,7 @@ from shapely.geometry import Polygon
 import geopandas as gpd
 from jinja2 import Template
 from pyproj import Geod
+import logging
 
 
 
@@ -249,12 +250,20 @@ class Map:
             fp.write(html)
             fp.close()
 
-    def fit_to_layers(self):
+    def fit_to_bounds(self, bounds=None):
         """
             Change zoom level to match plotted data
         """
-        self.map.fit_bounds(self.map.get_bounds())
-
+        # Use input bounds if provided
+        if bounds:
+            self.map.fit_bounds(bounds)
+        # Otherwise try to retrieve bounds automatically from map
+        else:
+            bounds = self.map.get_bounds()
+            if bounds == [[None, None], [None, None]]:
+                logging.info("No bounds returned, can't fit to layers")
+            else:
+                self.map.fit_bounds(bounds)
 
     def Paths(self,geojson,name,show=True,predefined=None,**kwargs):
         """


### PR DESCRIPTION
Fixes the issue described in #46. When plotting a mesh from the cli the map will now zoom straight to the data you have plotted. Can also be used in a notebook by calling the new `fit_to_layers` method.